### PR TITLE
Add `rows_mut` to state for mutable rows

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -16,32 +16,24 @@ impl Filter {
     match self {
       Self::Circle => {
         let (width, height) = state.dimensions();
-        state
-          .scalars_mut()
-          .chunks_mut(width * 3)
-          .enumerate()
-          .for_each(|(row, line)| {
-            line.iter_mut().enumerate().for_each(|(col, scalar)| {
-              if (col as i64 / 3 - (width as i64 / 2)).pow(2)
-                + (row as i64 - (height as i64 / 2)).pow(2)
-                <= (width as i64 / 2).pow(2)
-              {
-                *scalar = !*scalar;
-              }
-            })
-          });
+        let (width, height) = (width as f32, height as f32);
+        state.rows_mut().enumerate().for_each(|(row, line)| {
+          line.iter_mut().enumerate().for_each(|(col, scalar)| {
+            let (row, col) = (row as f32, col as f32);
+            if (col / 3.0 - (width / 2.0)).powf(2.0) + (row - (height / 2.0)).powf(2.0)
+              <= (width / 2.0).powf(2.0)
+            {
+              *scalar = !*scalar;
+            }
+          })
+        });
       }
       Self::Even => {
-        let (width, _) = state.dimensions();
-        state
-          .scalars_mut()
-          .chunks_mut(width * 3)
-          .enumerate()
-          .for_each(|(i, line)| {
-            if i & 1 == 0 {
-              line.iter_mut().for_each(|scalar| *scalar = !*scalar);
-            }
-          });
+        state.rows_mut().enumerate().for_each(|(i, row)| {
+          if i & 1 == 0 {
+            row.iter_mut().for_each(|scalar| *scalar = !*scalar);
+          }
+        });
       }
       Self::Generate { width, height } => {
         state.generate(*width, *height);
@@ -65,23 +57,15 @@ impl Filter {
       }
       Self::Square => {
         let (width, height) = state.dimensions();
-        let (x1, y1) = (width as i64 / 4, height as i64 / 4);
-        let (x2, y2) = (x1 + width as i64 / 2, y1 + height as i64 / 2);
-        state
-          .scalars_mut()
-          .chunks_mut(width * 3)
-          .enumerate()
-          .for_each(|(row, line)| {
-            line.iter_mut().enumerate().for_each(|(col, scalar)| {
-              if (col as i64 / 3) > (x1 as i64)
-                && (col as i64 / 3) < (x2 as i64)
-                && (row as i64) > (y1 as i64)
-                && (row as i64) < (y2 as i64)
-              {
-                *scalar = !*scalar;
-              }
-            })
-          });
+        let (x1, y1) = (width / 4, height / 4);
+        let (x2, y2) = (x1 + width / 2, y1 + height / 2);
+        state.rows_mut().enumerate().for_each(|(row, line)| {
+          line.iter_mut().enumerate().for_each(|(col, scalar)| {
+            if col / 3 > x1 && col / 3 < x2 && row > y1 && row < y2 {
+              *scalar = !*scalar;
+            }
+          })
+        });
       }
       Self::Pixelate { size } => {
         for row in 0..state.height() {
@@ -94,16 +78,12 @@ impl Filter {
         }
       }
       Self::Top => {
-        let (width, height) = state.dimensions();
-        state
-          .scalars_mut()
-          .chunks_mut(width * 3)
-          .enumerate()
-          .for_each(|(i, line)| {
-            if i < height / 2 {
-              line.iter_mut().for_each(|scalar| *scalar = !*scalar);
-            }
-          });
+        let height = state.height();
+        state.rows_mut().enumerate().for_each(|(i, row)| {
+          if i < height / 2 {
+            row.iter_mut().for_each(|scalar| *scalar = !*scalar);
+          }
+        });
       }
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use {
   crate::{arguments::Arguments, filter::Filter, state::State},
-  std::str::FromStr,
+  std::{slice::ChunksMut, str::FromStr},
   structopt::StructOpt,
 };
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,6 +53,10 @@ impl State {
     &mut self.buffer
   }
 
+  pub(crate) fn rows_mut(&mut self) -> ChunksMut<'_, u8> {
+    self.buffer.chunks_mut(self.width * 3)
+  }
+
   pub(crate) fn image(&self) -> Result<RgbImage> {
     ImageBuffer::from_raw(self.width as u32, self.height as u32, self.buffer.clone())
       .ok_or_else(|| "State is not valid image.".into())


### PR DESCRIPTION
- Adds a `rows_mut` method to `State` for grabbing mutable rows
- Modifies filters that use `chunks_mut` directly

I think this cleans things up a bit