### PR TITLE
Loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,8 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "rand",
+ "tempfile",
+ "unindent",
 ]
 
 [[package]]
@@ -511,6 +513,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "safe_arch"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +576,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "tiff"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +611,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ image = "0.23.14"
 nalgebra = "0.29.0"
 num-traits = "0.2.14"
 rand = "0.8.4"
+tempfile = "3.2.0"
+unindent = "0.1.7"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,12 +1,16 @@
 use super::*;
 
+#[derive(Clone, Debug)]
 pub(crate) enum Command {
   Filter(Filter),
+  For(usize),
+  Loop,
   Operation(Operation),
   Print,
   Repl,
-  Resize { rows: usize, cols: usize },
-  Save { path: PathBuf },
+  Resize((usize, usize)),
+  Save(PathBuf),
+  Verbose,
 }
 
 impl Command {
@@ -15,18 +19,42 @@ impl Command {
       Self::Filter(filter) => {
         for col in 0..state.matrix.ncols() {
           for row in 0..state.matrix.nrows() {
-            if filter.filter(state, col, row) {
+            if filter.filter(state, row, col) {
               state.matrix[(row, col)] = state.operation.apply(state, state.matrix[(row, col)]);
             }
           }
         }
+      }
+      Self::For(until) => {
+        if state.loop_counter >= *until {
+          loop {
+            state.program_counter = state.program_counter.wrapping_add(1);
+            if let Some(Self::Loop) | None = state.program.get(state.program_counter) {
+              break;
+            }
+          }
+          state.loop_counter = 0;
+        }
+      }
+      Self::Loop => {
+        loop {
+          state.program_counter = state.program_counter.wrapping_sub(1);
+          let next = state.program_counter.wrapping_add(1);
+          if next == 0 {
+            break;
+          }
+          if let Some(Self::For(_)) | None = state.program.get(next) {
+            break;
+          }
+        }
+        state.loop_counter += 1;
       }
       Self::Operation(operation) => state.operation = *operation,
       Self::Print => state.print()?,
       Self::Repl => {
         for result in BufReader::new(io::stdin()).lines() {
           let line = result?;
-          match line.trim().parse::<Command>() {
+          match line.trim().parse::<Self>() {
             Ok(command) => {
               command.apply(state)?;
               state.print()?;
@@ -37,10 +65,11 @@ impl Command {
           }
         }
       }
-      Self::Resize { rows, cols } => {
-        state.resize(Vector2::new(*rows, *cols));
+      Self::Resize(dimensions) => {
+        state.resize(*dimensions);
       }
-      Self::Save { path } => state.image()?.save(path)?,
+      Self::Save(path) => state.image()?.save(path)?,
+      Self::Verbose => state.verbose = !state.verbose,
     }
 
     Ok(())
@@ -55,7 +84,9 @@ impl FromStr for Command {
       ["all"] => Ok(Self::Filter(Filter::All)),
       ["circle"] => Ok(Self::Filter(Filter::Circle)),
       ["even"] => Ok(Self::Filter(Filter::Even)),
+      ["for", count] => Ok(Self::For(count.parse()?)),
       ["invert"] => Ok(Self::Operation(Operation::Invert)),
+      ["loop"] => Ok(Self::Loop),
       ["mod", divisor, remainder] => Ok(Self::Filter(Filter::Mod {
         divisor: divisor.parse()?,
         remainder: remainder.parse()?,
@@ -63,15 +94,11 @@ impl FromStr for Command {
       ["print"] => Ok(Self::Print),
       ["random"] => Ok(Self::Operation(Operation::Random)),
       ["repl"] => Ok(Self::Repl),
-      ["resize", cols, rows] => Ok(Self::Resize {
-        cols: cols.parse()?,
-        rows: rows.parse()?,
-      }),
-      ["save", path] => Ok(Self::Save {
-        path: path.parse()?,
-      }),
+      ["resize", cols, rows] => Ok(Self::Resize((rows.parse()?, cols.parse()?))),
+      ["save", path] => Ok(Self::Save(path.parse()?)),
       ["square"] => Ok(Self::Filter(Filter::Square)),
       ["top"] => Ok(Self::Filter(Filter::Top)),
+      ["verbose"] => Ok(Self::Verbose),
       _ => Err(format!("Invalid command: {}", s).into()),
     }
   }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Clone, Debug)]
 pub(crate) enum Filter {
   All,
   Circle,
@@ -10,7 +11,7 @@ pub(crate) enum Filter {
 }
 
 impl Filter {
-  pub(crate) fn filter(&self, state: &State, col: usize, row: usize) -> bool {
+  pub(crate) fn filter(&self, state: &State, row: usize, col: usize) -> bool {
     match self {
       Self::All => true,
       Self::Circle => {
@@ -27,10 +28,10 @@ impl Filter {
       }
       Self::Square => {
         let dimensions = state.dimensions();
-        let (x1, y1) = (dimensions.x as f32 / 4.0, dimensions.y as f32 / 4.0);
+        let (x1, y1) = (dimensions.1 as f32 / 4.0, dimensions.0 as f32 / 4.0);
         let (x2, y2) = (
-          x1 + dimensions.x as f32 / 2.0,
-          y1 + dimensions.y as f32 / 2.0,
+          x1 + dimensions.1 as f32 / 2.0,
+          y1 + dimensions.0 as f32 / 2.0,
         );
         let (row, col) = (row as f32, col as f32);
         col >= x1 && col < x2 && row >= y1 && row < y2

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use {
   crate::{command::Command, filter::Filter, operation::Operation, state::State},
   image::{ImageBuffer, RgbImage},
-  nalgebra::{DMatrix, Vector2, Vector3},
+  nalgebra::{DMatrix, Vector3},
   rand::Rng,
   std::{
     io::{self, BufRead, BufReader, BufWriter, Write},
     path::PathBuf,
+    process,
     str::FromStr,
   },
 };
@@ -18,6 +19,9 @@ mod state;
 type Error = Box<dyn std::error::Error>;
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
-fn main() -> Result<()> {
-  State::run()
+fn main() {
+  if let Err(error) = State::run() {
+    eprintln!("error: {}", error);
+    process::exit(1);
+  }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum Operation {
   Random,
   Invert,

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,22 +6,32 @@ use {
 };
 
 pub(crate) struct State {
+  pub(crate) loop_counter: usize,
   pub(crate) matrix: DMatrix<Vector3<u8>>,
   pub(crate) operation: Operation,
+  pub(crate) program: Vec<Command>,
+  pub(crate) program_counter: usize,
   pub(crate) rng: StdRng,
+  pub(crate) verbose: bool,
 }
 
 impl State {
   pub(crate) fn run() -> Result<()> {
-    let commands = env::args()
-      .skip(1)
-      .map(|arg| arg.parse())
-      .collect::<Result<Vec<Command>>>()?;
-
     let mut state = Self::new();
 
-    for command in commands {
+    for arg in env::args().skip(1) {
+      state.program.push(arg.parse()?);
+    }
+
+    while let Some(command) = state.program.get(state.program_counter).cloned() {
+      if state.verbose {
+        eprintln!(
+          "PC {} LC {} {:?}",
+          state.program_counter, state.loop_counter, command
+        );
+      }
       command.apply(&mut state)?;
+      state.program_counter = state.program_counter.wrapping_add(1);
     }
 
     Ok(())
@@ -29,18 +39,24 @@ impl State {
 
   pub(crate) fn new() -> Self {
     Self {
+      loop_counter: 0,
       matrix: DMatrix::zeros(0, 0),
       operation: Operation::Invert,
+      program: Vec::new(),
+      program_counter: 0,
       rng: StdRng::seed_from_u64(0),
+      verbose: false,
     }
   }
 
-  pub(crate) fn resize(&mut self, dim: Vector2<usize>) {
-    self.matrix.resize_mut(dim.x, dim.y, Zero::zero())
+  pub(crate) fn resize(&mut self, dimensions: (usize, usize)) {
+    self
+      .matrix
+      .resize_mut(dimensions.0, dimensions.1, Zero::zero())
   }
 
-  pub(crate) fn dimensions(&self) -> Vector2<usize> {
-    Vector2::new(self.matrix.ncols(), self.matrix.nrows())
+  pub(crate) fn dimensions(&self) -> (usize, usize) {
+    (self.matrix.nrows(), self.matrix.ncols())
   }
 
   pub(crate) fn image(&self) -> Result<RgbImage> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,71 +4,155 @@ use {
   std::{
     io::prelude::*,
     process::{Command, Stdio},
-    str,
+    str, thread,
+    time::Duration,
   },
+  tempfile::TempDir,
+  unindent::Unindent,
 };
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
-fn assert_output_eq(args: &str, expected_bitmap: &str) -> Result<()> {
-  let mut command = Command::new(executable_path("degenerate"));
+struct Test {
+  expected_status: i32,
+  expected_stderr: String,
+  expected_stdout: String,
+  program: String,
+  tempdir: TempDir,
+}
 
-  command.args(args.split_whitespace());
-
-  let output = command.output()?;
-
-  assert!(
-    output.status.success(),
-    "Command {:?} failed: {}",
-    command,
-    str::from_utf8(&output.stderr)?
-  );
-
-  let mut expected_bitmap = expected_bitmap.replace(" ", "");
-  if !expected_bitmap.is_empty() {
-    expected_bitmap.push('\n');
+impl Test {
+  fn new() -> Result<Self> {
+    Ok(Self {
+      expected_status: 0,
+      expected_stderr: String::new(),
+      expected_stdout: String::new(),
+      program: String::new(),
+      tempdir: TempDir::new()?,
+    })
   }
 
-  assert_eq!(str::from_utf8(&output.stdout)?, expected_bitmap);
+  fn program(self, program: &str) -> Self {
+    Self {
+      program: program.to_owned(),
+      ..self
+    }
+  }
 
-  Ok(())
+  fn expected_status(self, expected_status: i32) -> Self {
+    Self {
+      expected_status,
+      ..self
+    }
+  }
+
+  fn expected_stderr(self, expected_stderr: &str) -> Self {
+    Self {
+      expected_stderr: expected_stderr.unindent(),
+      ..self
+    }
+  }
+
+  fn expected_stdout(self, expected_stdout: &str) -> Self {
+    Self {
+      expected_stdout: expected_stdout.unindent(),
+      ..self
+    }
+  }
+
+  fn run(self) -> Result<()> {
+    self.run_and_return_tempdir().map(|_| ())
+  }
+
+  fn run_with_timeout(self, timeout: Duration) -> Result<()> {
+    let mut child = Command::new(executable_path("degenerate"))
+      .current_dir(&self.tempdir)
+      .args(self.program.split_whitespace())
+      .spawn()?;
+
+    thread::sleep(timeout);
+
+    if let Some(status) = child.try_wait()? {
+      panic!(
+        "program `{}` exited before timeout elapsed: {}",
+        self.program, status
+      );
+    }
+
+    Ok(())
+  }
+
+  fn run_and_return_tempdir(self) -> Result<TempDir> {
+    let output = Command::new(executable_path("degenerate"))
+      .current_dir(&self.tempdir)
+      .args(self.program.split_whitespace())
+      .output()?;
+
+    let stderr = str::from_utf8(&output.stderr)?;
+
+    assert_eq!(
+      output.status.code(),
+      Some(self.expected_status),
+      "Program `{}` failed: {}",
+      self.program,
+      stderr,
+    );
+
+    assert_eq!(stderr, self.expected_stderr);
+
+    assert_eq!(str::from_utf8(&output.stdout)?, self.expected_stdout);
+
+    Ok(self.tempdir)
+  }
 }
 
 #[test]
 fn circle() -> Result<()> {
-  assert_output_eq(
-    "resize:10:10 circle print",
-    "000FFFF000
-     0FFFFFFFF0
-     0FFFFFFFF0
-     FFFFFFFFFF
-     FFFFFFFFFF
-     FFFFFFFFFF
-     FFFFFFFFFF
-     0FFFFFFFF0
-     0FFFFFFFF0
-     000FFFF000",
-  )
+  Test::new()?
+    .program("resize:10:10 circle print")
+    .expected_stdout(
+      "
+      000FFFF000
+      0FFFFFFFF0
+      0FFFFFFFF0
+      FFFFFFFFFF
+      FFFFFFFFFF
+      FFFFFFFFFF
+      FFFFFFFFFF
+      0FFFFFFFF0
+      0FFFFFFFF0
+      000FFFF000
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn even() -> Result<()> {
-  assert_output_eq(
-    "resize:4:4 even print",
-    "FFFF
-     0000
-     FFFF
-     0000",
-  )
+  Test::new()?
+    .program("resize:4:4 even print")
+    .expected_stdout(
+      "
+      FFFF
+      0000
+      FFFF
+      0000
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn top() -> Result<()> {
-  assert_output_eq(
-    "resize:2:2 top print",
-    "FF
-     00",
-  )
+  Test::new()?
+    .program("resize:2:2 top print")
+    .expected_stdout(
+      "
+      FF
+      00
+      ",
+    )
+    .run()
 }
 
 #[test]
@@ -80,8 +164,7 @@ fn repl_valid_filter() -> Result<()> {
     .stderr(Stdio::piped())
     .spawn()?;
 
-  let stdin = command.stdin.as_mut().unwrap();
-  write!(stdin, "even")?;
+  write!(command.stdin.as_mut().unwrap(), "even")?;
 
   assert_eq!(
     str::from_utf8(&command.wait_with_output()?.stdout)?,
@@ -113,23 +196,44 @@ fn repl_invalid_filter() -> Result<()> {
 
 #[test]
 fn resize() -> Result<()> {
-  assert_output_eq("resize:2:1 print", "00")
+  Test::new()?
+    .program("resize:2:1 print")
+    .expected_stdout(
+      "
+      00
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn invert() -> Result<()> {
-  assert_output_eq("resize:1:1 all print", "F")
+  Test::new()?
+    .program("resize:1:1 all print")
+    .expected_stdout(
+      "
+      F
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn save() -> Result<()> {
-  assert_output_eq(
-    "resize:1:2 top save:output.png print",
-    "F
-     0",
-  )?;
+  let tempdir = Test::new()?
+    .program("resize:1:2 top save:output.png print")
+    .expected_stdout(
+      "
+      F
+      0
+      ",
+    )
+    .run_and_return_tempdir()?;
 
-  let image = image::open("output.png")?.as_rgb8().unwrap().to_owned();
+  let image = image::open(tempdir.path().join("output.png"))?
+    .as_rgb8()
+    .unwrap()
+    .to_owned();
   assert_eq!(image.width(), 1);
   assert_eq!(image.height(), 2);
   assert_eq!(image.to_vec(), &[255, 255, 255, 0, 0, 0]);
@@ -139,54 +243,134 @@ fn save() -> Result<()> {
 
 #[test]
 fn save_invalid_format() -> Result<()> {
-  let output = Command::new(executable_path("degenerate"))
-    .args(["resize:4:4", "top", "save:output.txt"])
-    .output()?;
-
-  assert!(!output.status.success());
-
-  Ok(())
+  Test::new()?
+    .program("resize:4:4 top save:output.txt")
+    .expected_status(1)
+    .expected_stderr(
+      "
+      error: The file extension `.\"txt\"` was not recognized as an image format
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn square() -> Result<()> {
-  assert_output_eq(
-    "resize:4:4 square print",
-    "0000
-     0FF0
-     0FF0
-     0000",
-  )
+  Test::new()?
+    .program("resize:4:4 square print")
+    .expected_stdout(
+      "
+      0000
+      0FF0
+      0FF0
+      0000
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn modulus() -> Result<()> {
-  assert_output_eq(
-    "resize:4:2 mod:2:0 print",
-    "FFFF
-     0000",
-  )
+  Test::new()?
+    .program("resize:4:2 mod:2:0 print")
+    .expected_stdout(
+      "
+      FFFF
+      0000
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn default_bitmap_size() -> Result<()> {
-  assert_output_eq("print", "")
+  Test::new()?.program("print").run()
 }
 
 #[test]
 fn random() -> Result<()> {
-  assert_output_eq(
-    "resize:4:2 random all print",
-    "8569
-     3275",
-  )
+  Test::new()?
+    .program("resize:4:2 random all print")
+    .expected_stdout(
+      "
+      8569
+      3275
+      ",
+    )
+    .run()
 }
 
 #[test]
 fn reset_filter() -> Result<()> {
-  assert_output_eq(
-    "resize:4:2 random all invert all print",
-    "7A96
-     CD8A",
-  )
+  Test::new()?
+    .program("resize:4:2 random all invert all print")
+    .expected_stdout(
+      "
+      7A96
+      CD8A
+      ",
+    )
+    .run()
+}
+
+#[test]
+fn verbose_toggles_step_status() -> Result<()> {
+  Test::new()?
+    .program("verbose square verbose square")
+    .expected_stderr(
+      "
+      PC 1 LC 0 Filter(Square)
+      PC 2 LC 0 Verbose
+      ",
+    )
+    .run()
+}
+
+#[test]
+fn looping() -> Result<()> {
+  Test::new()?
+    .program("resize:4:4 for:2 square print loop")
+    .expected_stdout(
+      "
+      0000
+      0FF0
+      0FF0
+      0000
+      0000
+      0000
+      0000
+      0000
+    ",
+    )
+    .run()
+}
+
+#[test]
+fn multiple_fors_reset_loop_counter() -> Result<()> {
+  Test::new()?
+    .program("resize:4:4 for:2 square print loop for:1 even print loop")
+    .expected_stdout(
+      "
+      0000
+      0FF0
+      0FF0
+      0000
+      0000
+      0000
+      0000
+      0000
+      FFFF
+      0000
+      FFFF
+      0000
+      ",
+    )
+    .run()
+}
+
+#[test]
+fn infinite_loop() -> Result<()> {
+  Test::new()?
+    .program("loop")
+    .run_with_timeout(Duration::from_millis(250))
 }


### PR DESCRIPTION
Depends on #51. Adds a `loop` command, which just loops forever.

Since degenerate is like a tiny computer, I used computer terminology. The `program` is the sequence of commands that are being run, and the `program_counter` is the the index of the next command to run. On a physical CPU, the program counter (also called the instruction pointer) is the address of the next instruction to run.

I did `cargo run square print loop` and it just hung, so I added the `verbose` command, which toggles the verbosity level, and makes it print the command its running and the program counter. Then I realized that I just didn't resize first.

I need to add tests.