### PR TITLE
Improve browser error handling

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,14 +1,15 @@
 use {
   self::{
     add_event_listener::AddEventListener, app::App, cast::Cast, get_document::GetDocument,
-    select::Select, stderr::Stderr, window::window,
+    js_value_error::JsValueError, select::Select, stderr::Stderr, window::window,
   },
   super::*,
   std::{
+    fmt::{self, Formatter},
     ops::Deref,
     sync::{Arc, Mutex},
   },
-  wasm_bindgen::{closure::Closure, JsCast},
+  wasm_bindgen::{closure::Closure, JsCast, JsValue},
   web_sys::{
     CanvasRenderingContext2d, Document, Element, EventTarget, HtmlCanvasElement, HtmlElement,
     HtmlTextAreaElement, Window,
@@ -22,6 +23,7 @@ mod app;
 mod cast;
 mod display;
 mod get_document;
+mod js_value_error;
 mod select;
 mod stderr;
 mod window;

--- a/src/browser/add_event_listener.rs
+++ b/src/browser/add_event_listener.rs
@@ -10,7 +10,7 @@ impl<T: Deref<Target = EventTarget>> AddEventListener for T {
     self
       .deref()
       .add_event_listener_with_callback(event, &closure.as_ref().dyn_ref().unwrap())
-      .map_err(|err| format!("Failed to set event listener: {:?}", err))?;
+      .map_err(JsValueError)?;
     closure.forget();
     Ok(())
   }

--- a/src/browser/app.rs
+++ b/src/browser/app.rs
@@ -29,7 +29,7 @@ impl App {
 
     let context = canvas
       .get_context("2d")
-      .map_err(|err| format!("`canvas.get_context(\"2d\")` failed: {:?}", err))?
+      .map_err(JsValueError)?
       .ok_or_else(|| format!("failed to retrieve context"))?
       .cast::<CanvasRenderingContext2d>()?;
 
@@ -98,7 +98,7 @@ impl App {
           .dyn_ref()
           .unwrap(),
       )
-      .map_err(|err| format!("`window.requestAnimationFrame` failed: {:?}", err))?;
+      .map_err(JsValueError)?;
 
     self.animation_frame_pending = true;
 

--- a/src/browser/cast.rs
+++ b/src/browser/cast.rs
@@ -9,7 +9,7 @@ impl<V: JsCast + std::fmt::Debug> Cast for V {
     Ok(
       self
         .dyn_into::<T>()
-        .map_err(|err| format!("`cast` failed: {:?}", err))?,
+        .map_err(|value| format!("`cast` failed for value: {:?}", value))?,
     )
   }
 }

--- a/src/browser/display.rs
+++ b/src/browser/display.rs
@@ -18,12 +18,12 @@ impl Display {
       wasm_bindgen::Clamped(&pixels),
       memory.ncols().try_into()?,
     )
-    .map_err(|err| format!("failed to create image data: {:?}", err))?;
+    .map_err(JsValueError)?;
 
     self
       .context
       .put_image_data(&image_data, 0.0, 0.0)
-      .map_err(|err| format!("failed to put image data: {:?}", err))?;
+      .map_err(JsValueError)?;
 
     Ok(())
   }

--- a/src/browser/js_value_error.rs
+++ b/src/browser/js_value_error.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+#[derive(Debug)]
+pub(crate) struct JsValueError(pub(crate) JsValue);
+
+impl fmt::Display for JsValueError {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "error: {}", self.to_string())
+  }
+}
+
+impl std::error::Error for JsValueError {}

--- a/src/browser/select.rs
+++ b/src/browser/select.rs
@@ -9,7 +9,7 @@ impl Select for Document {
     Ok(
       self
         .query_selector(selector)
-        .map_err(|err| format!("`select` failed: {:?}", err))?
+        .map_err(JsValueError)?
         .ok_or_else(|| format!("selector `{}` returned no elements", selector))?,
     )
   }


### PR DESCRIPTION
This adds a `JsValueError` type that can wrap a `JsValue` and implements `std::error::Error`. This allows easily converting errors from web-sys functions to rust errors.