### PR TITLE
Disable auto-capitalization in editor

### DIFF
--- a/justfile
+++ b/justfile
@@ -74,7 +74,7 @@ doc-web:
 	cargo doc --open --target wasm32-unknown-unknown
 
 serve:
-	python3 -m http.server --directory www
+	python3 -m http.server --directory www --bind 0.0.0.0
 
 build-web:
 	cargo build --target wasm32-unknown-unknown

--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
   <body>
     <canvas></canvas>
     <samp></samp>
-    <textarea autofocus></textarea>
+    <textarea autofocus autocapitalize="off"></textarea>
     <nav>
       <div>D</div>
       <div>E</div>


### PR DESCRIPTION
Fixes #218. This disables auto-capitalization in the editor. Tested on my iPhone.