### PR TITLE
Disable auto-zoom when editing on mobile

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>D E G E N E R A T E</title>
     <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js" defer></script>


### PR DESCRIPTION
On mobile, when you select the text area, the browser zooms in. This PR disables that. We might also want to make sure that the font size is large enough on mobile, so that zooming in isn't necessary, but we can do that in a separate PR.

Fixes #219.