### PR TITLE
Remove unused comment:slow

### DIFF
--- a/tests/image_tests.rs
+++ b/tests/image_tests.rs
@@ -95,13 +95,13 @@ image_test! {
 
 image_test! {
   name: brilliance,
-  program: "comment:slow x rotate-color:g:0.07 rotate:0.07 for:10 apply loop rotate-color:b:0.09 rotate:0.09 for:10 apply loop save",
+  program: "x rotate-color:g:0.07 rotate:0.07 for:10 apply loop rotate-color:b:0.09 rotate:0.09 for:10 apply loop save",
   ignore: true,
 }
 
 image_test! {
   name: carpet,
-  program: "comment:slow circle scale:0.5 for:8 apply wrap loop save",
+  program: "circle scale:0.5 for:8 apply wrap loop save",
   ignore: true,
 }
 
@@ -117,7 +117,7 @@ image_test! {
 
 image_test! {
   name: concentric_circles,
-  program: "comment:slow scale:0.99 circle for:100 apply loop save",
+  program: "scale:0.99 circle for:100 apply loop save",
   ignore: true,
 }
 
@@ -133,19 +133,19 @@ image_test! {
 
 image_test! {
   name: diamonds,
-  program: "comment:slow rotate:0.3333 rotate-color:g:0.05 circle scale:0.5 wrap for:8 apply loop rotate:0.8333 rotate-color:b:0.05 for:8 apply loop save",
+  program: "rotate:0.3333 rotate-color:g:0.05 circle scale:0.5 wrap for:8 apply loop rotate:0.8333 rotate-color:b:0.05 for:8 apply loop save",
   ignore: true,
 }
 
 image_test! {
   name: grain,
-  program: "comment:slow rotate:0.111 for:16 square apply circle apply loop save",
+  program: "rotate:0.111 for:16 square apply circle apply loop save",
   ignore: true,
 }
 
 image_test! {
   name: kaleidoscope,
-  program: "comment:slow rotate-color:g:0.05 circle scale:0.75 wrap for:8 apply loop rotate:0.8333 rotate-color:b:0.05 for:8 apply loop save",
+  program: "rotate-color:g:0.05 circle scale:0.75 wrap for:8 apply loop rotate:0.8333 rotate-color:b:0.05 for:8 apply loop save",
   ignore: true,
 }
 
@@ -156,13 +156,13 @@ image_test! {
 
 image_test! {
   name: orbs,
-  program: "comment:slow rotate-color:g:0.05 circle scale:0.75 wrap for:8 apply loop rotate-color:b:0.05 for:8 apply loop save",
+  program: "rotate-color:g:0.05 circle scale:0.75 wrap for:8 apply loop rotate-color:b:0.05 for:8 apply loop save",
   ignore: true,
 }
 
 image_test! {
   name: pattern,
-  program: "comment:slow alpha:0.75 circle scale:0.5 for:8 apply wrap loop save",
+  program: "alpha:0.75 circle scale:0.5 for:8 apply wrap loop save",
   ignore: true,
 }
 
@@ -293,7 +293,7 @@ image_test! {
 
 image_test! {
   name: rug,
-  program: "comment:slow rotate-color:g:0.05 circle scale:0.5 wrap for:8 apply loop rotate-color:b:0.05 for:8 apply loop save",
+  program: "rotate-color:g:0.05 circle scale:0.5 wrap for:8 apply loop rotate-color:b:0.05 for:8 apply loop save",
   ignore: true,
 }
 
@@ -314,7 +314,7 @@ image_test! {
 
 image_test! {
   name: scale_circle_for,
-  program: "comment:slow circle scale:0.5 for:8 apply loop save",
+  program: "circle scale:0.5 for:8 apply loop save",
   ignore: true,
 }
 
@@ -340,7 +340,7 @@ image_test! {
 
 image_test! {
   name: smear,
-  program: "comment:slow seed:19798 rotate-color:g:0.01 rotate:0.01 for:100 random-mask apply loop rotate-color:b:0.01 rotate:0.01 for:100 random-mask apply loop save",
+  program: "seed:19798 rotate-color:g:0.01 rotate:0.01 for:100 random-mask apply loop rotate-color:b:0.01 rotate:0.01 for:100 random-mask apply loop save",
   ignore: true,
 }
 
@@ -356,7 +356,7 @@ image_test! {
 
 image_test! {
   name: starburst,
-  program: "comment:slow seed:12462 rotate-color:g:0.1 rotate:0.1 for:10 random-mask apply loop rotate-color:b:0.1 rotate:0.1 for:10 random-mask apply loop save",
+  program: "seed:12462 rotate-color:g:0.1 rotate:0.1 for:10 random-mask apply loop rotate-color:b:0.1 rotate:0.1 for:10 random-mask apply loop save",
   ignore: true,
 }
 
@@ -427,13 +427,13 @@ image_test! {
 
 image_test! {
   name: x_loop,
-  program: "comment:slow x scale:0.5 for:8 apply wrap loop save",
+  program: "x scale:0.5 for:8 apply wrap loop save",
   ignore: true,
 }
 
 image_test! {
   name: x_scale,
-  program: "comment:slow x scale:0.5 for:8 apply loop save",
+  program: "x scale:0.5 for:8 apply loop save",
   ignore: true,
 }
 


### PR DESCRIPTION
We're now using `ignore: true`, so `comment:slow` is no longer required.