### PR TITLE
Only run one server per test run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "once_cell",
  "pin-project-lite",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ executable-path = "1.0.0"
 futures = "0.3.21"
 pretty_assertions = "1.0.0"
 tempfile = "3.2.0"
-tokio = { version = "1.18.2", features = ["rt", "macros"] }
+tokio = { version = "1.18.2", features = ["macros", "rt", "rt-multi-thread"] }
 tower-http = { version = "0.3.0", features = ["fs", "trace"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/tests/image_tests/browser.rs
+++ b/tests/image_tests/browser.rs
@@ -96,14 +96,13 @@ fn setup() -> u16 {
     }
 
     eprintln!("Done with setup!");
-    let rt = Box::new(Runtime::new().unwrap());
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let listener = std::net::TcpListener::bind(addr).unwrap();
     let port = listener.local_addr().unwrap().port();
     drop(listener);
 
-    rt.spawn(async move {
+    Box::leak(Box::new(Runtime::new().unwrap())).spawn(async move {
       let addr = SocketAddr::from(([127, 0, 0, 1], port));
       tracing::trace!("Listening on {}", addr);
 
@@ -115,8 +114,6 @@ fn setup() -> u16 {
 
       task::spawn(async move { server.await.unwrap() });
     });
-
-    Box::leak(rt);
 
     PORT.store(port, Ordering::Relaxed);
   });


### PR DESCRIPTION
I noticed a race condition during browser tests where we would find an empty port, but it would be grabbed by another server before we bound to it. This creates a single server per test run, instead of creating one per test, so it avoids the race condition.