### PR TITLE
Avoid infinite recursion in Display impl for JsValueError

### DIFF
--- a/src/browser/js_value_error.rs
+++ b/src/browser/js_value_error.rs
@@ -5,7 +5,7 @@ pub(crate) struct JsValueError(pub(crate) JsValue);
 
 impl fmt::Display for JsValueError {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(f, "error: {}", self)
+    write!(f, "error: {:?}", self.0)
   }
 }
 


### PR DESCRIPTION
This was caught by the latest version of rust, so it's making all our builds fail.