### PR TITLE
Reform GPU rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ features = [
   "Location",
   "WebGl2RenderingContext",
   "WebGlBuffer",
+  "WebGlContextAttributes",
   "WebGlFramebuffer",
   "WebGlProgram",
   "WebGlShader",

--- a/src/computer.rs
+++ b/src/computer.rs
@@ -79,7 +79,7 @@ impl Computer {
 
   fn apply(&mut self) -> Result {
     if let Some(gpu) = self.gpu.as_ref() {
-      gpu.lock().unwrap().render_to_texture(self)?;
+      gpu.lock().unwrap().apply(self)?;
     } else {
       let similarity = self.similarity.inverse();
       let size = self.size();

--- a/src/computer.rs
+++ b/src/computer.rs
@@ -193,7 +193,7 @@ impl Computer {
 
   pub(crate) fn resize(&mut self, size: usize) -> Result {
     if let Some(gpu) = self.gpu.as_ref() {
-      gpu.lock().unwrap().resize(size)?;
+      gpu.lock().unwrap().resize()?;
     } else {
       self.memory.resize_mut(size, size, self.default);
     }

--- a/src/fragment.glsl
+++ b/src/fragment.glsl
@@ -24,14 +24,14 @@ vec4 apply_operation(vec4 pixel) {
   }
 }
 
-bool is_masked() {
+bool is_masked(vec2 position) {
   switch (mask) {
     // X
     case 0u:
-      return min(abs((1.0 - uv.x) - uv.y), abs(uv.x - uv.y)) < 0.125;
+      return abs(abs(position.x) - abs(position.y)) < 0.25;
     // Circle
     case 1u:
-      return length((uv - 0.5) * 2.0) < 1.0;
+      return length(position) < 1.0;
     // All
     case 2u:
        return true;
@@ -43,5 +43,6 @@ bool is_masked() {
 
 void main() {
   vec4 pixel = texture(source, uv);
-  color = is_masked() ? apply_operation(pixel) : vec4(pixel.xyz, 1.0);
+  vec2 position = uv.xy * 2.0 - 1.0;
+  color = is_masked(position) ? apply_operation(pixel) : vec4(pixel.xyz, 1.0);
 }

--- a/src/fragment.glsl
+++ b/src/fragment.glsl
@@ -41,8 +41,7 @@ bool is_masked(vec2 position) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / float(resolution);
-  vec4 pixel = texture(source, uv);
-  vec2 position = uv.xy * 2.0 - 1.0;
+  vec2 position = gl_FragCoord.xy / float(resolution) * 2.0 - 1.0;
+  vec4 pixel = texelFetch(source, ivec2(gl_FragCoord.xy), 0);
   color = is_masked(position) ? apply_operation(pixel) : vec4(pixel.xyz, 1.0);
 }

--- a/src/fragment.glsl
+++ b/src/fragment.glsl
@@ -41,7 +41,7 @@ bool is_masked(vec2 position) {
 }
 
 void main() {
+  vec4 pixel = texelFetch(source, ivec2(gl_FragCoord.xy - 0.5), 0);
   vec2 position = gl_FragCoord.xy / float(resolution) * 2.0 - 1.0;
-  vec4 pixel = texelFetch(source, ivec2(gl_FragCoord.xy), 0);
   color = is_masked(position) ? apply_operation(pixel) : vec4(pixel.xyz, 1.0);
 }

--- a/src/fragment.glsl
+++ b/src/fragment.glsl
@@ -5,8 +5,7 @@ precision highp float;
 uniform sampler2D source;
 uniform uint mask;
 uniform uint operation;
-
-in vec2 uv;
+uniform uint resolution;
 
 out vec4 color;
 
@@ -42,6 +41,7 @@ bool is_masked(vec2 position) {
 }
 
 void main() {
+  vec2 uv = gl_FragCoord.xy / float(resolution);
   vec4 pixel = texture(source, uv);
   vec2 position = uv.xy * 2.0 - 1.0;
   color = is_masked(position) ? apply_operation(pixel) : vec4(pixel.xyz, 1.0);

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -11,10 +11,6 @@ pub(crate) struct Gpu {
 }
 
 impl Gpu {
-  const VERTICES: [f32; 12] = [
-    -1.0, -1.0, 1.0, -1.0, 1.0, 1.0, 1.0, 1.0, -1.0, 1.0, -1.0, -1.0,
-  ];
-
   pub(super) fn new(canvas: &HtmlCanvasElement) -> Result<Self> {
     let gl = canvas
       .get_context("webgl2")
@@ -83,33 +79,6 @@ impl Gpu {
       .get_uniform_location(&program, "operation")
       .ok_or("Could not find uniform `operation`")?;
 
-    let vertices = Float32Array::new_with_length(Self::VERTICES.len().try_into()?);
-    vertices.copy_from(&Self::VERTICES);
-
-    let position = gl.get_attrib_location(&program, "position");
-
-    gl.bind_buffer(
-      WebGl2RenderingContext::ARRAY_BUFFER,
-      gl.create_buffer().as_ref(),
-    );
-
-    gl.buffer_data_with_opt_array_buffer(
-      WebGl2RenderingContext::ARRAY_BUFFER,
-      Some(&vertices.buffer()),
-      WebGl2RenderingContext::STATIC_DRAW,
-    );
-
-    gl.enable_vertex_attrib_array(position.try_into()?);
-
-    gl.vertex_attrib_pointer_with_i32(
-      position.try_into()?,
-      2,
-      WebGl2RenderingContext::FLOAT,
-      false,
-      0,
-      0,
-    );
-
     let textures = [
       Self::create_texture(&gl, canvas.width().try_into()?)?,
       Self::create_texture(&gl, canvas.width().try_into()?)?,
@@ -149,11 +118,7 @@ impl Gpu {
       Self::operation_uniform(&Operation::Identity),
     );
 
-    self.gl.draw_arrays(
-      WebGl2RenderingContext::TRIANGLES,
-      0,
-      (Self::VERTICES.len() / 2).try_into()?,
-    );
+    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
 
     Ok(())
   }
@@ -186,11 +151,7 @@ impl Gpu {
       Self::operation_uniform(computer.operation()),
     );
 
-    self.gl.draw_arrays(
-      WebGl2RenderingContext::TRIANGLES,
-      0,
-      (Self::VERTICES.len() / 2).try_into()?,
-    );
+    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
 
     self.source_texture.set(self.source_texture.get() ^ 1);
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -22,6 +22,8 @@ impl Gpu {
       .ok_or("Failed to retrieve webgl2 context")?
       .cast::<WebGl2RenderingContext>()?;
 
+    gl.enable(WebGl2RenderingContext::CULL_FACE);
+
     let program = {
       let program = gl.create_program().ok_or("Failed to create program")?;
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -177,24 +177,6 @@ impl Gpu {
       size as i32,
     );
 
-    gl.tex_parameteri(
-      WebGl2RenderingContext::TEXTURE_2D,
-      WebGl2RenderingContext::TEXTURE_MIN_FILTER,
-      WebGl2RenderingContext::LINEAR.try_into()?,
-    );
-
-    gl.tex_parameteri(
-      WebGl2RenderingContext::TEXTURE_2D,
-      WebGl2RenderingContext::TEXTURE_WRAP_S,
-      WebGl2RenderingContext::CLAMP_TO_EDGE.try_into()?,
-    );
-
-    gl.tex_parameteri(
-      WebGl2RenderingContext::TEXTURE_2D,
-      WebGl2RenderingContext::TEXTURE_WRAP_T,
-      WebGl2RenderingContext::CLAMP_TO_EDGE.try_into()?,
-    );
-
     Ok(texture)
   }
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -118,7 +118,7 @@ impl Gpu {
       Self::operation_uniform(&Operation::Identity),
     );
 
-    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
+    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 3);
 
     Ok(())
   }
@@ -151,7 +151,7 @@ impl Gpu {
       Self::operation_uniform(computer.operation()),
     );
 
-    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
+    self.gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 3);
 
     self.source_texture.set(self.source_texture.get() ^ 1);
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -166,7 +166,7 @@ impl Gpu {
     Ok(())
   }
 
-  pub(crate) fn render_to_texture(&self, computer: &Computer) -> Result {
+  pub(crate) fn apply(&self, computer: &Computer) -> Result {
     self.gl.bind_framebuffer(
       WebGl2RenderingContext::FRAMEBUFFER,
       Some(&self.frame_buffer),

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -151,8 +151,8 @@ impl Gpu {
     let dy = (resolution - height) / 2;
 
     self.gl.blit_framebuffer(
-      0 + dx,
-      0 + dy,
+      dx,
+      dy,
       width + dx,
       height + dy,
       0,

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -30,8 +30,6 @@ impl Gpu {
       .ok_or("Failed to retrieve webgl2 context")?
       .cast::<WebGl2RenderingContext>()?;
 
-    log::info!("{:?}", gl.get_context_attributes());
-
     gl.enable(WebGl2RenderingContext::CULL_FACE);
 
     let program = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use {
     js_value_error::JsValueError, mask::Mask, operation::Operation, select::Select, stderr::Stderr,
     window::window, wrap::Wrap,
   },
-  js_sys::Float32Array,
   nalgebra::{
     Affine2, DMatrix, Matrix3, Point2, Rotation3, Similarity2, UnitComplex, Vector2, Vector3,
     Vector4,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ use {
   wasm_bindgen::{closure::Closure, prelude::wasm_bindgen, JsCast, JsValue},
   web_sys::{
     CanvasRenderingContext2d, Document, Element, EventTarget, HtmlCanvasElement, HtmlElement,
-    HtmlTextAreaElement, ImageData, WebGl2RenderingContext, WebGlFramebuffer, WebGlTexture,
-    WebGlUniformLocation, Window,
+    HtmlTextAreaElement, ImageData, WebGl2RenderingContext, WebGlContextAttributes,
+    WebGlFramebuffer, WebGlTexture, WebGlUniformLocation, Window,
   },
 };
 

--- a/src/vertex.glsl
+++ b/src/vertex.glsl
@@ -1,9 +1,9 @@
 #version 300 es
 
-in vec2 position;
 out vec2 uv;
 
 void main() {
-  uv = position.xy * 0.5 + 0.5;
-  gl_Position = vec4(position, 0.0, 1.0);
+  vec2 vertices[3]= vec2[3](vec2(-1, -1), vec2(3, -1), vec2(-1, 3));
+  gl_Position = vec4(vertices[gl_VertexID], 0, 1);
+  uv = 0.5 * gl_Position.xy + vec2(0.5);
 }

--- a/src/vertex.glsl
+++ b/src/vertex.glsl
@@ -1,9 +1,9 @@
 #version 300 es
 
-in vec4 position;
+in vec2 position;
 out vec2 uv;
 
 void main() {
   uv = position.xy * 0.5 + 0.5;
-  gl_Position = position;
+  gl_Position = vec4(position, 0.0, 1.0);
 }

--- a/src/vertex.glsl
+++ b/src/vertex.glsl
@@ -1,9 +1,14 @@
 #version 300 es
 
+// Generate a single screen-filling triangle.
+// See this post for details:
+// https://stackoverflow.com/a/59739538/66450
+
 out vec2 uv;
 
+const vec2 vertices[3]= vec2[3](vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+
 void main() {
-  vec2 vertices[3]= vec2[3](vec2(-1, -1), vec2(3, -1), vec2(-1, 3));
-  gl_Position = vec4(vertices[gl_VertexID], 0, 1);
-  uv = 0.5 * gl_Position.xy + vec2(0.5);
+  gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+  uv = (gl_Position.xy + 1.0) / 2.0;
 }

--- a/src/vertex.glsl
+++ b/src/vertex.glsl
@@ -4,11 +4,8 @@
 // See this post for details:
 // https://stackoverflow.com/a/59739538/66450
 
-out vec2 uv;
-
-const vec2 vertices[3]= vec2[3](vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+const vec2 VERTICES[3] = vec2[3](vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
 
 void main() {
-  gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
-  uv = (gl_Position.xy + 1.0) / 2.0;
+  gl_Position = vec4(VERTICES[gl_VertexID], 0.0, 1.0);
 }


### PR DESCRIPTION
This fixes all our problems. There's a bunch of stuff here:

- First off, instead of sending vertices to the vertex shader, we just generate them in the vertex shader.
- Switch from rendering using two triangles to a triangle that's large enough to cover the screen. This will sometimes avoid duplicate calls to the fragment shader for pixels where the two triangles touch.
- Don't pass anything from the vertex shader to the fragment shader, calculate everything in the vertex shader.
- Use texelFetch in the fragment shader. This looks up pixels directly in the texture, instead of going through blending, etc.

But the biggest change, and the ones that fixes everything:

- Don't do the final copy from the rendered texture to the canvas with shaders and a call to drawarrays, instead use `gl.blit_framebuffer`, to directly copy pixels. I think this fixes the weird transform stuff we were seeing, and simplifies everything a lot.

The commits mostly make sense individually, so it might be easier to review by looking at each commit.