### PR TITLE
Use radians instead of turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ that can be programmed with JavaScript. It is deployed at
 
 - Paste this code into the text area:
   ```
-  rotateColor('green', 0.05);
+  rotateColor('green', 0.05 * TAU);
   circle();
   scale(0.75);
   wrap();
   for (let i = 0; i < 8; i++) {
     render();
   }
-  rotate(0.8333);
-  rotateColor('blue', 0.05);
+  rotate(0.8333 * TAU);
+  rotateColor('blue', 0.05 * TAU);
   for (let i = 0; i < 8; i++) {
     render();
   }

--- a/man/src/chapter_1.md
+++ b/man/src/chapter_1.md
@@ -14,12 +14,12 @@ happen to those pixels.
 
 For example, to set the mask to an X, you can do `x()`, and to set the
 operation to color rotation by one half rotation about the green axis, do
-`rotateColor('green', 0.5)`. An finally, to see the results, do `render()`. The
-complete program looks like this:
+`rotateColor('green', 0.5 * TAU)`. An finally, to see the results, do
+`render()`. The complete program looks like this:
 
 ```javascript
 x();
-rotateColor('green', 0.5);
+rotateColor('green', 0.5 * TAU);
 render();
 ```
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -232,13 +232,13 @@ impl Gpu {
     self.gl.uniform_matrix3fv_with_f32_array(
       Some(self.uniform("color_rotation")),
       false,
-      Rotation3::new(axis_vector * state.operation_rotate_color_turns * f32::consts::TAU)
+      Rotation3::new(axis_vector * state.operation_rotate_color_radians)
         .matrix()
         .as_slice(),
     );
 
     let mut similarity = Similarity2::<f32>::identity();
-    similarity.append_rotation_mut(&UnitComplex::from_angle(-state.rotation * f32::consts::TAU));
+    similarity.append_rotation_mut(&UnitComplex::from_angle(-state.rotation));
     similarity.append_scaling_mut(state.scale);
 
     self.gl.uniform_matrix3fv_with_f32_array(

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,7 +12,7 @@ pub(crate) struct State {
   pub(crate) mask_rows_step: u32,
   pub(crate) operation: u32,
   pub(crate) operation_rotate_color_axis: String,
-  pub(crate) operation_rotate_color_turns: f32,
+  pub(crate) operation_rotate_color_radians: f32,
   pub(crate) rotation: f32,
   pub(crate) scale: f32,
   pub(crate) wrap: bool,

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -95,13 +95,13 @@ const tests = {
   `,
   brilliance: `
     x();
-    rotateColor('green', 0.07);
-    rotate(0.07);
+    rotateColor('green', 0.07 * TAU);
+    rotate(0.07 * TAU);
     for (let i = 0; i < 10; i++) {
       render();
     }
-    rotateColor('blue', 0.09);
-    rotate(0.09);
+    rotateColor('blue', 0.09 * TAU);
+    rotate(0.09 * TAU);
     for (let i = 0; i < 10; i++) {
       render();
     }
@@ -140,22 +140,22 @@ const tests = {
   `,
   default_program: ` `,
   diamonds: `
-    rotate(0.3333);
-    rotateColor('green', 0.05);
+    rotate(0.3333 * TAU);
+    rotateColor('green', 0.05 * TAU);
     circle();
     scale(0.5);
     wrap();
     for (let i = 0; i < 8; i++) {
       render();
     }
-    rotate(0.8333);
-    rotateColor('blue', 0.05);
+    rotate(0.8333 * TAU);
+    rotateColor('blue', 0.05 * TAU);
     for (let i = 0; i < 8; i++) {
       render();
     }
   `,
   grain: `
-    rotate(0.111);
+    rotate(0.111 * TAU);
     for (let i = 0; i < 16; i++) {
       square();
       render();
@@ -164,15 +164,15 @@ const tests = {
     }
   `,
   kaleidoscope: `
-    rotateColor('green', 0.05);
+    rotateColor('green', 0.05 * TAU);
     circle();
     scale(0.75);
     wrap();
     for (let i = 0; i < 8; i++) {
       render();
     }
-    rotate(0.8333);
-    rotateColor('blue', 0.05);
+    rotate(0.8333 * TAU);
+    rotateColor('blue', 0.05 * TAU);
     for (let i = 0; i < 8; i++) {
       render();
     }
@@ -182,14 +182,14 @@ const tests = {
     render();
   `,
   orbs: `
-    rotateColor('green', 0.05);
+    rotateColor('green', 0.05 * TAU);
     circle();
     scale(0.75);
     wrap();
     for (let i = 0; i < 8; i++) {
       render();
     }
-    rotateColor('blue', 0.05);
+    rotateColor('blue', 0.05 * TAU);
     for (let i = 0; i < 8; i++) {
       render();
     }
@@ -222,35 +222,35 @@ const tests = {
     render();
   `,
   rotate: `
-    rotate(0.05);
+    rotate(0.05 * TAU);
     x();
     render();
   `,
   rotate_0125_square: `
-    rotate(0.125);
+    rotate(0.125 * TAU);
     square();
     render();
   `,
   rotate_1_square: `
-    rotate(1.0);
+    rotate(1.0 * TAU);
     square();
     render();
   `,
   rotate_scale_x: `
-    rotate(0.05);
+    rotate(0.05 * TAU);
     scale(2);
     x();
     render();
   `,
   rotate_square: `
-    rotate(0.05);
+    rotate(0.05 * TAU);
     square();
     for (let i = 0; i < 2; i++) {
       render();
     }
   `,
   rotate_square_for_x: `
-    rotate(0.05);
+    rotate(0.05 * TAU);
     square();
     for (let i = 0; i < 2; i++) {
       render();
@@ -269,14 +269,14 @@ const tests = {
     render();
   `,
   rug: `
-    rotateColor('green', 0.05);
+    rotateColor('green', 0.05 * TAU);
     circle();
     scale(0.5);
     wrap();
     for (let i = 0; i < 8; i++) {
       render();
     }
-    rotateColor('blue', 0.05);
+    rotateColor('blue', 0.05 * TAU);
     for (let i = 0; i < 8; i++) {
       render();
     }
@@ -301,7 +301,7 @@ const tests = {
   `,
   scale_rotate: `
     scale(2);
-    rotate(0.05);
+    rotate(0.05 * TAU);
     x();
     render();
   `,
@@ -313,14 +313,14 @@ const tests = {
   smear: `
     const masks = [all, circle, cross, square, top, x];
     rng.seed(9);
-    rotateColor('green', 0.01);
-    rotate(0.01);
+    rotateColor('green', 0.01 * TAU);
+    rotate(0.01 * TAU);
     for (let i = 0; i < 100; i++) {
       rng.choose(masks)();
       render();
     }
-    rotateColor('blue', 0.01);
-    rotate(0.01);
+    rotateColor('blue', 0.01 * TAU);
+    rotate(0.01 * TAU);
     for (let i = 0; i < 100; i++) {
       rng.choose(masks)();
       render();
@@ -339,8 +339,8 @@ const tests = {
   starburst: `
     const masks = [all, circle, cross, square, top, x];
     rng.seed(3);
-    rotateColor('green', 0.1);
-    rotate(0.1);
+    rotateColor('green', 0.1 * TAU);
+    rotate(0.1 * TAU);
     for (let i = 0; i < 10; i++) {
       rng.choose(masks)();
       render();
@@ -349,8 +349,8 @@ const tests = {
       rng.choose(masks)();
       render();
     }
-    rotateColor('blue', 0.1);
-    rotate(0.1);
+    rotateColor('blue', 0.1 * TAU);
+    rotate(0.1 * TAU);
     for (let i = 0; i < 10; i++) {
       rng.choose(masks)();
       render();
@@ -397,8 +397,8 @@ const tests = {
     render();
   `,
   square_colors: `
-    rotate(0.01);
-    rotateColor('green', 0.1);
+    rotate(0.01 * TAU);
+    rotateColor('green', 0.1 * TAU);
     square();
     for (let i = 0; i < 10; i++) {
       render();
@@ -420,42 +420,42 @@ const tests = {
     }
   `,
   gpu_extra_pixels: `
-    rotate(0.01);
+    rotate(0.01 * TAU);
     render();
     render();
   `,
   default_color: `
     defaultColor([255, 0, 255]);
-    rotate(0.01);
+    rotate(0.01 * TAU);
     render();
   `,
   rotate_color_05_red: `
-    rotateColor('red', 0.5);
+    rotateColor('red', 0.5 * TAU);
     all();
     render();
   `,
   rotate_color_blue_05_all: `
-    rotateColor('blue', 0.5);
+    rotateColor('blue', 0.5 * TAU);
     all();
     render();
   `,
   rotate_color_green: `
-    rotateColor('green', 0.5);
+    rotateColor('green', 0.5 * TAU);
     all();
     render();
   `,
   rotate_color_blue_1_all: `
-    rotateColor('blue', 1.0);
+    rotateColor('blue', 1.0 * TAU);
     all();
     render();
   `,
   rotate_color_green_all: `
-    rotateColor('green', 1.0);
+    rotateColor('green', 1.0 * TAU);
     all();
     render();
   `,
   rotate_color_red_all: `
-    rotateColor('red', 1.0);
+    rotateColor('red', 1.0 * TAU);
     all();
     render();
   `,

--- a/www/worker.js
+++ b/www/worker.js
@@ -18,6 +18,9 @@ class Rng {
   }
 }
 
+const PI = Math.PI;
+const TAU = Math.PI * 2;
+
 const MASK_ALL = 0;
 const MASK_CHECK = 1;
 const MASK_CIRCLE = 2;
@@ -109,7 +112,7 @@ function reset() {
     maskRowsStep: 0,
     operation: OPERATION_INVERT,
     operationRotateColorAxis: 'red',
-    operationRotateColorTurns: 0.0,
+    operationRotateColorRadians: 0.0,
     rotation: 0.0,
     scale: 1.0,
     wrap: false,
@@ -125,9 +128,9 @@ function rotate(rotation) {
   state.rotation += rotation;
 }
 
-function rotateColor(axis, turns) {
+function rotateColor(axis, radians) {
   state.operationRotateColorAxis = axis;
-  state.operationRotateColorTurns = turns;
+  state.operationRotateColorRadians = radians;
   state.operation = OPERATION_ROTATE_COLOR;
 }
 


### PR DESCRIPTION
I think overall this is a good change, even though it's annoying to have to write `turns * TAU` or `turns * 2 * PI`

- A lot of graphics wind up using trig functions, and those always take radians
- Turns, although very simple, are not standard