### PR TITLE
Get rid of high-frequency logging

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -223,8 +223,6 @@ impl App {
 
     self.gpu.resize()?;
 
-    log::trace!("Animation frame timestamp {}s", timestamp);
-
     self
       .worker
       .post_message(&JsValue::from_str(&serde_json::to_string(

--- a/src/app.rs
+++ b/src/app.rs
@@ -218,7 +218,7 @@ impl App {
     Ok(())
   }
 
-  fn on_animation_frame(&mut self, timestamp: f64) -> Result {
+  fn on_animation_frame(&mut self, _timestamp: f64) -> Result {
     self.request_animation_frame()?;
 
     self.gpu.resize()?;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -220,8 +220,6 @@ impl Gpu {
   }
 
   pub(crate) fn render(&mut self, filter: &Filter) -> Result {
-    log::trace!("Applying filter {:?}", filter);
-
     self.resize()?;
 
     self.gl.bind_framebuffer(


### PR DESCRIPTION
Remove high-frequency logging. This has been bothering me for a little bit. These can be ignored, but there's still a little number which increments like crazy.