### PR TITLE
Use fragment instead of path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ features = [
   "DomTokenList",
   "Element",
   "GainNode",
-  "History",
   "HtmlAnchorElement",
   "HtmlButtonElement",
   "HtmlCanvasElement",

--- a/bin/serve/src/main.rs
+++ b/bin/serve/src/main.rs
@@ -11,9 +11,7 @@ use {
     net::SocketAddr,
     process::{self, Command},
   },
-  tower_http::{
-    services::ServeDir, services::ServeFile, set_header::SetResponseHeaderLayer, trace::TraceLayer,
-  },
+  tower_http::{services::ServeDir, set_header::SetResponseHeaderLayer, trace::TraceLayer},
   tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
 };
 
@@ -46,14 +44,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
   let router = Router::new()
     .fallback(
-      get_service(ServeDir::new("www").fallback(ServeFile::new("www/index.html"))).handle_error(
-        |err| async move {
-          (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("I/O error: {}", err),
-          )
-        },
-      ),
+      get_service(ServeDir::new("www")).handle_error(|err| async move {
+        (
+          StatusCode::INTERNAL_SERVER_ERROR,
+          format!("I/O error: {}", err),
+        )
+      }),
     )
     .layer(SetResponseHeaderLayer::overriding(
       header::CACHE_CONTROL,

--- a/src/app.rs
+++ b/src/app.rs
@@ -513,12 +513,10 @@ impl App {
     let script = self.textarea.value();
 
     if !script.is_empty() {
-      let hex = hex::encode(script);
-      let path = format!("#/program/{hex}");
       self
         .window
-        .history()?
-        .replace_state_with_url(&JsValue::NULL, "", Some(&path))?;
+        .location()
+        .set_hash(&format!("#/program/{}", hex::encode(script)))?;
     }
 
     Ok(())

--- a/www/404.html
+++ b/www/404.html
@@ -1,1 +1,0 @@
-index.html


### PR DESCRIPTION
Browsers and google don't behave well with pages that return 404s, so switch to using fragments instead of paths for accessing loader and sharing programs.