### PR TITLE
Move interpreter state into class

### DIFF
--- a/examples/starburst.js
+++ b/examples/starburst.js
@@ -2,14 +2,14 @@ reboot();
 
 const fields = [all, circle, cross, square, top, x];
 
-rng.seed(3);
+seed(3);
 
 rotateColor('green', 0.1 * TAU);
 
 rotate(0.1 * TAU);
 
 for (let i = 0; i < 20; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }
 
@@ -18,6 +18,6 @@ rotateColor('blue', 0.1 * TAU);
 rotate(0.2 * TAU);
 
 for (let i = 0; i < 10; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }

--- a/features/choose_default_seed.js
+++ b/features/choose_default_seed.js
@@ -1,2 +1,2 @@
-rng.choose([all, circle, cross, square, top, x])();
+choose([all, circle, cross, square, top, x])();
 render();

--- a/features/choose_nonzero_seed.js
+++ b/features/choose_nonzero_seed.js
@@ -1,3 +1,3 @@
-rng.seed(3);
-rng.choose([all, circle, cross, square, top, x])();
+seed(3);
+choose([all, circle, cross, square, top, x])();
 render();

--- a/features/choose_zero_seed.js
+++ b/features/choose_zero_seed.js
@@ -1,3 +1,3 @@
-rng.seed(0);
-rng.choose([all, circle, cross, square, top, x])();
+seed(0);
+choose([all, circle, cross, square, top, x])();
 render();

--- a/features/smear.js
+++ b/features/smear.js
@@ -1,14 +1,14 @@
 const fields = [all, circle, cross, square, top, x];
-rng.seed(9);
+seed(9);
 rotateColor('green', 0.01 * TAU);
 rotate(0.01 * TAU);
 for (let i = 0; i < 100; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }
 rotateColor('blue', 0.01 * TAU);
 rotate(0.02 * TAU);
 for (let i = 0; i < 100; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }

--- a/features/starburst.js
+++ b/features/starburst.js
@@ -1,14 +1,14 @@
 const fields = [all, circle, cross, square, top, x];
-rng.seed(3);
+seed(3);
 rotateColor('green', 0.1 * TAU);
 rotate(0.1 * TAU);
 for (let i = 0; i < 20; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }
 rotateColor('blue', 0.1 * TAU);
 rotate(0.2 * TAU);
 for (let i = 0; i < 10; i++) {
-  rng.choose(fields)();
+  choose(fields)();
   render();
 }

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -84,7 +84,7 @@ function checkbox(name) {
       },
     })
   );
-  return !!state.widgets['checkbox-' + name];
+  return !!widgets['checkbox-' + name];
 }
 
 // A circle.
@@ -353,7 +353,7 @@ function radio(name, options) {
       },
     })
   );
-  return state.widgets['radio-' + name] ?? options[0];
+  return widgets['radio-' + name] ?? options[0];
 }
 
 // Reset the image filter and clear the canvas.
@@ -532,7 +532,7 @@ function slider(name, min, max, step, initial) {
       },
     })
   );
-  return state.widgets['slider-' + name] ?? initial;
+  return widgets['slider-' + name] ?? initial;
 }
 
 // A square field.
@@ -666,7 +666,6 @@ class Filter {
 class State {
   constructor() {
     this.frameCallbacks = [];
-    this.widgets = {};
   }
 }
 
@@ -676,6 +675,7 @@ let lastFrame = 0;
 let rng = null;
 let start = Date.now();
 let state = null;
+let widgets = {};
 
 self.addEventListener('message', async function (event) {
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
@@ -705,7 +705,7 @@ self.addEventListener('message', async function (event) {
       self.postMessage(JSON.stringify('done'));
       break;
     case 'widget':
-      state.widgets[message.content.key] = message.content.value;
+      widgets[message.content.key] = message.content.value;
       break;
   }
 });

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -700,10 +700,10 @@ class State {
     this.rng = new Rng();
     this.start = Date.now();
     this.filter = new Filter();
+    this.frame = this.start;
   }
 }
 
-let lastFrame = 0;
 let state = null;
 let widgets = {};
 
@@ -717,12 +717,10 @@ self.addEventListener('message', async function (event) {
           callback();
         }
         state.frameCallbacks.length = 0;
+        let now = Date.now();
+        state.delta = now - state.frame;
+        state.frame = now;
       }
-      let now = Date.now();
-      if (state && lastFrame > 0) {
-        state.delta = now - lastFrame;
-      }
-      lastFrame = now;
       break;
     case 'script':
       state = new State();

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -60,6 +60,15 @@ function check() {
   filter.field = 'Check';
 }
 
+// Choose a random element from `array`.
+//
+// ```
+// scale(choose([1,2,3]));
+// ```
+function choose(array) {
+  return state.rng.choose(array);
+}
+
 // Create a new checkbox widget with the label `name`, and return true if it is
 // checked. Calls with same `name` will all refer to the same checkbox, making
 // it safe to call repeatedly.
@@ -478,6 +487,20 @@ function save() {
   self.postMessage(JSON.stringify('save'));
 }
 
+// Seed RNG with `n`.
+//
+// ```
+// seed(1);
+// let a = choose([1,2,3]);
+// seed(1);
+// let b = choose([1,2,3]);
+// console.assert(a == b);
+// ```
+function seed(n) {
+  state.rng.seed(n);
+}
+
+
 // Set the current scale to `scale`. The scale factor is applied to sample coordinates before
 // looking up the pixel under those coordinates.
 //
@@ -666,13 +689,13 @@ class Filter {
 class State {
   constructor() {
     this.frameCallbacks = [];
+    this.rng = new Rng();
   }
 }
 
 let filter = new Filter();
 let lastDelta = 0;
 let lastFrame = 0;
-let rng = null;
 let start = Date.now();
 let state = null;
 let widgets = {};
@@ -695,7 +718,6 @@ self.addEventListener('message', async function (event) {
       lastFrame = now;
       break;
     case 'script':
-      rng = new Rng();
       state = new State();
       try {
         await new AsyncFunction(message.content)();

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -185,7 +185,7 @@ function defaultColor(defaultColor) {
 // }
 // ```
 function delta() {
-  return lastDelta;
+  return state.delta;
 }
 
 // Return the number of milliseconds that have elapsed since the page was loaded.
@@ -688,13 +688,13 @@ class Filter {
 
 class State {
   constructor() {
+    this.delta = 0;
     this.frameCallbacks = [];
     this.rng = new Rng();
   }
 }
 
 let filter = new Filter();
-let lastDelta = 0;
 let lastFrame = 0;
 let start = Date.now();
 let state = null;
@@ -712,8 +712,8 @@ self.addEventListener('message', async function (event) {
         state.frameCallbacks.length = 0;
       }
       let now = Date.now();
-      if (lastFrame > 0) {
-        lastDelta = now - lastFrame;
+      if (state && lastFrame > 0) {
+        state.delta = now - lastFrame;
       }
       lastFrame = now;
       break;

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -500,7 +500,6 @@ function seed(n) {
   state.rng.seed(n);
 }
 
-
 // Set the current scale to `scale`. The scale factor is applied to sample coordinates before
 // looking up the pixel under those coordinates.
 //
@@ -599,8 +598,16 @@ function top() {
 // ```
 function transform(rotation, scale, translation) {
   mat3.identity(state.filter.positionTransform);
-  mat3.rotate(state.filter.positionTransform, state.filter.positionTransform, rotation);
-  mat3.scale(state.filter.positionTransform, state.filter.positionTransform, scale);
+  mat3.rotate(
+    state.filter.positionTransform,
+    state.filter.positionTransform,
+    rotation
+  );
+  mat3.scale(
+    state.filter.positionTransform,
+    state.filter.positionTransform,
+    scale
+  );
   mat3.translate(
     state.filter.positionTransform,
     state.filter.positionTransform,

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -28,7 +28,7 @@ let vec4 = glMatrix.vec4;
 // render();
 // ```
 function all() {
-  filter.field = 'All';
+  state.filter.field = 'All';
 }
 
 // Set the alpha blending factor. `alpha` will be used to blend the
@@ -40,7 +40,7 @@ function all() {
 // render();
 // ```
 function alpha(alpha) {
-  filter.alpha = alpha;
+  state.filter.alpha = alpha;
 }
 
 // Assert that `condition` is true, otherwise throw `message`.
@@ -57,7 +57,7 @@ function assert(condition, message) {
 // render();
 // ```
 function check() {
-  filter.field = 'Check';
+  state.filter.field = 'Check';
 }
 
 // Choose a random element from `array`.
@@ -103,7 +103,7 @@ function checkbox(name) {
 // render();
 // ```
 function circle() {
-  filter.field = 'Circle';
+  state.filter.field = 'Circle';
 }
 
 // Clear the canvas.
@@ -124,7 +124,7 @@ function clear() {
 // render();
 // ```
 function cross() {
-  filter.field = 'Cross';
+  state.filter.field = 'Cross';
 }
 
 // Set the decibel range for normalization of raw frequency data into values
@@ -167,7 +167,7 @@ function decibelRange(min, max) {
 // render();
 // ```
 function defaultColor(defaultColor) {
-  filter.defaultColor = defaultColor;
+  state.filter.defaultColor = defaultColor;
 }
 
 // Return the number of milliseconds that have elapsed between this frame and the last.
@@ -213,7 +213,7 @@ function elapsed() {
 // }
 // ```
 function equalizer() {
-  filter.field = 'Equalizer';
+  state.filter.field = 'Equalizer';
 }
 
 // Returns a promise that resolves when the browser is ready to display a new
@@ -238,7 +238,7 @@ async function frame() {
 
 // A frequency field.
 function frequency() {
-  filter.field = 'Frequency';
+  state.filter.field = 'Frequency';
 }
 
 // Set the color transformation to the identity transformation. The identity
@@ -251,7 +251,7 @@ function frequency() {
 // render();
 // ```
 function identity() {
-  mat4.identity(filter.colorTransform);
+  mat4.identity(state.filter.colorTransform);
 }
 
 // If `coordinates` is true, use the coordinate of the sample as the input color,
@@ -265,7 +265,7 @@ function identity() {
 // render();
 // ```
 function coordinates(coordinates) {
-  filter.coordinates = coordinates;
+  state.filter.coordinates = coordinates;
 }
 
 // Set the color transformation to inversion.
@@ -284,7 +284,7 @@ function coordinates(coordinates) {
 // render();
 // ```
 function invert() {
-  mat4.fromScaling(filter.colorTransform, vec3.fromValues(-1, -1, -1));
+  mat4.fromScaling(state.filter.colorTransform, vec3.fromValues(-1, -1, -1));
 }
 
 // Field that covers pixels where the pixel's index mod `divisor` is equal to `remainder`.
@@ -294,7 +294,7 @@ function invert() {
 // render();
 // ```
 function mod(divisor, remainder) {
-  filter.field = { Mod: { divisor, remainder } };
+  state.filter.field = { Mod: { divisor, remainder } };
 }
 
 // Set the oscillator gain. The oscillator produces a sine wave tone, useful
@@ -395,7 +395,7 @@ function record() {
 // }
 // ```
 async function render() {
-  self.postMessage(JSON.stringify({ render: filter }));
+  self.postMessage(JSON.stringify({ render: state.filter }));
   await frame();
 }
 
@@ -407,7 +407,7 @@ async function render() {
 // reset();
 // ```
 function reset() {
-  filter = new Filter();
+  state.filter = new Filter();
 }
 
 // Set resolution to a fixed value. Normally, the resolution increases and
@@ -442,13 +442,13 @@ function resolution(resolution) {
 function rotateColor(axis, radians) {
   switch (axis) {
     case 'red':
-      mat4.fromXRotation(filter.colorTransform, radians);
+      mat4.fromXRotation(state.filter.colorTransform, radians);
       break;
     case 'green':
-      mat4.fromYRotation(filter.colorTransform, radians);
+      mat4.fromYRotation(state.filter.colorTransform, radians);
       break;
     case 'blue':
-      mat4.fromZRotation(filter.colorTransform, radians);
+      mat4.fromZRotation(state.filter.colorTransform, radians);
       break;
   }
 }
@@ -472,7 +472,7 @@ function rotate(rotation) {
 // render();
 // ```
 function rows(on, off) {
-  filter.field = { Rows: { on, off } };
+  state.filter.field = { Rows: { on, off } };
 }
 
 // Save the current canvas as a PNG.
@@ -565,17 +565,17 @@ function slider(name, min, max, step, initial) {
 // render();
 // ```
 function square() {
-  filter.field = 'Square';
+  state.filter.field = 'Square';
 }
 
 // A field that covers pixels where the audio time domain data is large.
 function timeDomain() {
-  filter.field = 'TimeDomain';
+  state.filter.field = 'TimeDomain';
 }
 
 // Execute the filter `times` times.
 function times(times) {
-  filter.times = times;
+  state.filter.times = times;
 }
 
 // A field covering the top half of the canvas.
@@ -585,7 +585,7 @@ function times(times) {
 // render();
 // ```
 function top() {
-  filter.field = 'Top';
+  state.filter.field = 'Top';
 }
 
 // Set the coordinate transform using `rotation`, `scale`, and `translation`.
@@ -598,12 +598,12 @@ function top() {
 // render();
 // ```
 function transform(rotation, scale, translation) {
-  mat3.identity(filter.positionTransform);
-  mat3.rotate(filter.positionTransform, filter.positionTransform, rotation);
-  mat3.scale(filter.positionTransform, filter.positionTransform, scale);
+  mat3.identity(state.filter.positionTransform);
+  mat3.rotate(state.filter.positionTransform, state.filter.positionTransform, rotation);
+  mat3.scale(state.filter.positionTransform, state.filter.positionTransform, scale);
   mat3.translate(
-    filter.positionTransform,
-    filter.positionTransform,
+    state.filter.positionTransform,
+    state.filter.positionTransform,
     translation
   );
 }
@@ -619,7 +619,7 @@ function transform(rotation, scale, translation) {
 // }
 // ```
 function wave() {
-  filter.field = 'Wave';
+  state.filter.field = 'Wave';
 }
 
 // Set wrap. When `wrap` is `true`, out of bounds samples will be wrapped back within bounds.
@@ -631,7 +631,7 @@ function wave() {
 // render();
 // ```
 function wrap(warp) {
-  filter.wrap = warp;
+  state.filter.wrap = warp;
 }
 
 // An X field.
@@ -641,7 +641,7 @@ function wrap(warp) {
 // render();
 // ```
 function x() {
-  filter.field = 'X';
+  state.filter.field = 'X';
 }
 
 // The ratio of a circle's circumference to its diameter. Useful for expressing
@@ -692,10 +692,10 @@ class State {
     this.frameCallbacks = [];
     this.rng = new Rng();
     this.start = Date.now();
+    this.filter = new Filter();
   }
 }
 
-let filter = new Filter();
 let lastFrame = 0;
 let state = null;
 let widgets = {};

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -199,7 +199,7 @@ function delta() {
 // }
 // ```
 function elapsed() {
-  return Date.now() - start;
+  return Date.now() - state.start;
 }
 
 // An equalizer pattern.
@@ -691,12 +691,12 @@ class State {
     this.delta = 0;
     this.frameCallbacks = [];
     this.rng = new Rng();
+    this.start = Date.now();
   }
 }
 
 let filter = new Filter();
 let lastFrame = 0;
-let start = Date.now();
 let state = null;
 let widgets = {};
 


### PR DESCRIPTION
I want to start resetting interpreter state every frame, so this commit moves interpreter state into a class.

However, moving and resetting the `widgets` object into the state object breaks the tests.