### PR TITLE
Call script every frame

### DIFF
--- a/examples/kaleidoscope.js
+++ b/examples/kaleidoscope.js
@@ -1,32 +1,29 @@
-let r = 5 / 6 * TAU;
+if (this.r == undefined) {
+  this.r = 5 / 6 * TAU;
+}
+
 let s = 1 / 0.75;
 
-while(true) {
-  reboot();
+reboot();
 
-  rotateColor('green', 0.05 * TAU);
+rotateColor('green', 0.05 * TAU);
 
-  circle();
+circle();
 
-  scale(s);
+scale(s);
 
-  wrap(true);
+wrap(true);
 
-  for (let i = 0; i < 8; i++) {
-    render();
-  }
+times(8);
 
-  if (checkbox('rotate')) {
-    r += delta() / 30000 * TAU;
-  }
+render();
 
-  transform(r, [s, s], [0, 0]);
-
-  rotateColor('blue', 0.05 * TAU);
-
-  for (let i = 0; i < 8; i++) {
-    render();
-  }
-
-  await frame();
+if (checkbox('rotate')) {
+  this.r += delta() / 30000 * TAU;
 }
+
+transform(this.r, [s, s], [0, 0]);
+
+rotateColor('blue', 0.05 * TAU);
+
+render();

--- a/src/app.rs
+++ b/src/app.rs
@@ -231,7 +231,14 @@ impl App {
     if event.shift_key() && event.key() == "Enter" {
       event.prevent_default();
       self.run_script(&self.textarea.value())?;
+    } else if event.ctrl_key() && event.key() == "Enter" {
+      self
+        .worker
+        .post_message(&JsValue::from_str(&serde_json::to_string(&Event::Frame(
+          0.0,
+        ))?))?;
     }
+
     Ok(())
   }
 
@@ -270,11 +277,11 @@ impl App {
 
     self.gpu.resize()?;
 
-    self
-      .worker
-      .post_message(&JsValue::from_str(&serde_json::to_string(&Event::Frame(
-        timestamp as f32,
-      ))?))?;
+    // self
+    //   .worker
+    //   .post_message(&JsValue::from_str(&serde_json::to_string(&Event::Frame(
+    //     timestamp as f32,
+    //   ))?))?;
 
     Ok(())
   }

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -23,8 +23,8 @@ async function imageBuffer(page) {
 
 async function run(page, script) {
   await page.locator('textarea').fill(script);
-  await page.keyboard.down('Shift');
-  await page.keyboard.press('Enter');
+  await page.keyboard.press('Shift+Enter');
+  await page.keyboard.press('Control+Enter');
   await page.waitForSelector('html.done');
 
   let messages = await page.locator('samp > *');
@@ -147,12 +147,13 @@ test('elapsed', async ({ page }) => {
   await run(
     page,
     `
-      let first = elapsed();
-      await sleep(100);
-      let second = elapsed();
-
-      if (second <= first) {
-        throw "Arrow of time is broken!";
+      if (this.first == undefined) {
+        this.first = elapsed();
+      } else {
+        let second = elapsed();
+        if (second <= first) {
+          throw "Arrow of time is broken!";
+        }
       }
     `
   );
@@ -306,7 +307,6 @@ test('delta', async ({ page }) => {
   await run(
     page,
     `
-      await frame();
       let x = delta();
       if (x === 0) {
         throw "Frame delta was zero: " + x;

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -311,11 +311,18 @@ test('delta', async ({ page }) => {
   await run(
     page,
     `
-      if (delta() === 0) {
+      if (this.elapsed == undefined) {
+        this.elapsed = 0;
+      }
+
+      if (this.elapsed + delta() != elapsed()) {
         throw "Frame delta was zero.";
       }
+
+      this.elapsed += delta();
     `
   );
+  await sleep(10);
 });
 
 test('run', async ({ page }) => {

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -27,7 +27,7 @@ async function run(page, script) {
   await animation_frame(page);
 }
 
-async function animation_frame(page, script) {
+async function animation_frame(page) {
   await page.keyboard.press('Control+Enter');
   await page.waitForSelector('html.done');
 
@@ -326,6 +326,8 @@ test('run', async ({ page }) => {
   );
 
   await page.locator('button', { hasText: 'run' }).click();
+
+  await animation_frame(page);
 
   await page.waitForSelector('html.done');
 

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -329,15 +329,9 @@ test('delta', async ({ page }) => {
 });
 
 test('run', async ({ page }) => {
-  await page.locator('textarea').fill(
-    `
-      render();
-    `
-  );
+  await page.locator('textarea').fill('render();');
 
   await page.locator('button', { hasText: 'run' }).click();
-
-  await sleep(10);
 
   await animation_frame(page);
 

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -324,6 +324,8 @@ test('delta', async ({ page }) => {
   );
   await sleep(10);
   await animation_frame(page);
+  await sleep(10);
+  await animation_frame(page);
 });
 
 test('run', async ({ page }) => {
@@ -334,6 +336,8 @@ test('run', async ({ page }) => {
   );
 
   await page.locator('button', { hasText: 'run' }).click();
+
+  await sleep(10);
 
   await animation_frame(page);
 

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -323,6 +323,7 @@ test('delta', async ({ page }) => {
     `
   );
   await sleep(10);
+  await animation_frame(page);
 });
 
 test('run', async ({ page }) => {

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -24,6 +24,10 @@ async function imageBuffer(page) {
 async function run(page, script) {
   await page.locator('textarea').fill(script);
   await page.keyboard.press('Shift+Enter');
+  await animation_frame(page);
+}
+
+async function animation_frame(page, script) {
   await page.keyboard.press('Control+Enter');
   await page.waitForSelector('html.done');
 
@@ -44,7 +48,7 @@ test.beforeAll(async () => {
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 256, height: 256 });
-  await page.goto(`http://localhost:${process.env.PORT}`);
+  await page.goto(`http://localhost:${process.env.PORT}/#/test`);
   await page.evaluate('window.preserveDrawingBuffer = true');
   page.on('pageerror', (error) => {
     console.log(error.message);
@@ -307,9 +311,8 @@ test('delta', async ({ page }) => {
   await run(
     page,
     `
-      let x = delta();
-      if (x === 0) {
-        throw "Frame delta was zero: " + x;
+      if (delta() === 0) {
+        throw "Frame delta was zero.";
       }
     `
   );

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -678,10 +678,10 @@ class State {
     this.delta = 0;
     this.environment = {}; // todo: test
     this.filter = new Filter();
-    this.frame = this.start;
     this.rng = new Rng();
     this.script = new Function(script);
     this.start = Date.now();
+    this.frame = this.start;
   }
 }
 

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -374,9 +374,8 @@ function record() {
 //   await render();
 // }
 // ```
-async function render() {
+function render() {
   self.postMessage(JSON.stringify({ render: state.filter }));
-  await frame();
 }
 
 // Reset the image filter.
@@ -491,19 +490,6 @@ function seed(n) {
 // ```
 function scale(scale) {
   transform(0, [scale, scale], [0.0, 0.0]);
-}
-
-// Return a promise that resolves after `ms` milliseconds.
-//
-// ```
-// circle();
-// render();
-// await sleep(1000);
-// scale(0.5);
-// render();
-// ```
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Create a new slider widget with the given `name`, `min`, `max`, `step`, and
@@ -693,12 +679,8 @@ self.addEventListener('message', async function (event) {
   switch (message.tag) {
     case 'frame':
       if (state) {
-        let done = state.script.call(state.environment);
-        if (done === true) {
-          self.postMessage(JSON.stringify('done'));
-          state = null;
-          break;
-        }
+        state.script.call(state.environment);
+        self.postMessage(JSON.stringify('done'));
         let now = Date.now();
         state.delta = now - state.frame;
         state.frame = now;

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -682,7 +682,11 @@ self.addEventListener('message', async function (event) {
         let now = Date.now();
         state.delta = now - state.frame;
         state.frame = now;
-        state.script.call(state.environment);
+        try {
+          state.script.call(state.environment);
+        } catch (error) {
+          self.postMessage(JSON.stringify({ error: error.toString() }));
+        }
         self.postMessage(JSON.stringify('done'));
       }
       break;

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -679,11 +679,11 @@ self.addEventListener('message', async function (event) {
   switch (message.tag) {
     case 'frame':
       if (state) {
-        state.script.call(state.environment);
-        self.postMessage(JSON.stringify('done'));
         let now = Date.now();
         state.delta = now - state.frame;
         state.frame = now;
+        state.script.call(state.environment);
+        self.postMessage(JSON.stringify('done'));
       }
       break;
     case 'script':

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -216,26 +216,6 @@ function equalizer() {
   state.filter.field = 'Equalizer';
 }
 
-// Returns a promise that resolves when the browser is ready to display a new
-// frame. Call `await frame()` in your rendering loop to only render when
-// necessary and make sure each frame is displayed after rendering.
-//
-// ```
-// scale(0.99);
-// while (true) {
-//   circle();
-//   render();
-//   x()
-//   render();
-//   await frame();
-// }
-// ```
-async function frame() {
-  await new Promise((resolve, reject) => {
-    state.frameCallbacks.push(resolve);
-  });
-}
-
 // A frequency field.
 function frequency() {
   state.filter.field = 'Frequency';
@@ -699,7 +679,6 @@ class State {
     this.environment = {}; // todo: test
     this.filter = new Filter();
     this.frame = this.start;
-    this.frameCallbacks = [];
     this.rng = new Rng();
     this.script = new Function(script);
     this.start = Date.now();
@@ -720,7 +699,6 @@ self.addEventListener('message', async function (event) {
           state = null;
           break;
         }
-        state.frameCallbacks.length = 0;
         let now = Date.now();
         state.delta = now - state.frame;
         state.frame = now;

--- a/www/interpreter.js
+++ b/www/interpreter.js
@@ -199,7 +199,7 @@ function delta() {
 // }
 // ```
 function elapsed() {
-  return Date.now() - state.start;
+  return state.frame - state.start;
 }
 
 // An equalizer pattern.


### PR DESCRIPTION
Writing for loops and indenting code is annoying. This PR attempts to change the JS programming model from one in which you must call `await frame()` in a loop to one where the script is called every frame.